### PR TITLE
fix: set PATH correctly for execute step

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -129,6 +129,8 @@ runs:
         # CD Infra-live directory && Run Pipelines-execute
         cd ${{ inputs.infra_live_directory }}
 
+        export PATH="$HOME/.tfenv/bin:$HOME/tgswitch:$PATH"
+
         pipelines execute terragrunt \
           --working-directory ${{ inputs.working_directory }} \
           --command "${{ inputs.terragrunt_command }}" \


### PR DESCRIPTION
Set `PATH` variable correctly in the execute step.

Note that environment variables set in steps, do not have an effect on subsequent steps. If you want to do that, you need to use GITHUB_ENV or something.