### PR TITLE
Only use terraform of we're explicitly told to do so

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ inputs:
     required: false
     default: "1.6.1"
   tf_binary:
-    description: "Whether to use opentofu or terraform as the binary. Ignored if generate_mise_toml is false."
+    description: "Whether to use opentofu or terraform as the binary."
     required: false
     default: "opentofu"
     # These are the valid options, but not enforced by the action

--- a/action.yml
+++ b/action.yml
@@ -144,8 +144,10 @@ runs:
         # CD Infra-live directory && Run Pipelines-execute
         cd ${{ inputs.infra_live_directory }}
 
-        if [ "${{ inputs.tf_binary }}" == "opentofu" ]
+        if [ "${{ inputs.tf_binary }}" == "terraform" ]
         then
+          export TERRAGRUNT_TFPATH=terraform
+        else
           export TERRAGRUNT_TFPATH=tofu
         fi
 


### PR DESCRIPTION
Previously the only way we used OpenTofu was if the `tf_binary` was explicitly set to "opentofu".  With this change we invert the logic -- only get Terraform if `tf_binary` is explicitly set to "terraform".  This means that edge cases or other invalid input, such as `tf_binary` is somehow an empty string still default to OpenTofu.